### PR TITLE
patch to access sce reduced dimensions

### DIFF
--- a/R/createConfig.R
+++ b/R/createConfig.R
@@ -47,7 +47,7 @@ createConfig <- function(obj, meta.to.include = NA, legendCols = 4,
   } else if (class(obj)[1] == "SingleCellExperiment"){
     # SCE Object
     objMeta = SingleCellExperiment::colData(obj)
-    if(length(SingleCellExperiment::reducedDimNames(sce)) == 0){drExist=FALSE}
+    if(length(SingleCellExperiment::reducedDimNames(obj)) == 0){drExist=FALSE}
     
   } else if (tolower(tools::file_ext(obj)) == "h5ad"){
     # h5ad file


### PR DESCRIPTION
Couldn't access reducedDimNames of an sce object if it wasn't named 'sce'.